### PR TITLE
Fix/ci gh action to make DOCKERHUB creds work

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
           echo "Version: ${{ inputs.version }}"
 
   build:
-    environment: main
+    environment: CD
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,20 +7,20 @@ on:
     # manually triggered only
     inputs:
       version:
-        description: 'image version (tag)'
+        description: "image version (tag)"
 
 jobs:
   printInputs:
     runs-on: ubuntu-latest
     steps:
-    - run: |
-        echo "Version: ${{ inputs.version }}"
+      - run: |
+          echo "Version: ${{ inputs.version }}"
 
   build:
     environment: main
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # https://github.com/docker/login-action#docker-hub
       - name: Docker login


### PR DESCRIPTION
more alignment with bootstrap-cli gh-action
- updated from v3 to `uses: actions/checkout@v4`
- switched to `environment: CD` as DOCKERHUB secrets are only available in here
- need to merge to main, as gh-action needs to run from a protected branch (like `main`)